### PR TITLE
url参数只encode了第一个&，造成多个参数时，后面的参数丢失

### DIFF
--- a/background.js
+++ b/background.js
@@ -57,7 +57,7 @@ chrome.browserAction.onClicked.addListener( tab => {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: 'url=' + tab.url.replace('&', '%26'),
+    body: 'url=' + tab.url.replace(/&/g, '%26'),
   }).then(response => {
     return response.text();
   }).then(text => {


### PR DESCRIPTION
如xxx.kaola.com?pid=97&mid=230&id=2537转换会丢失后面的id